### PR TITLE
Bump xmlbf to 0.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ resolver: lts-11.1
 extra-deps:
   - html-entities-1.1.4.2
   - libxml-0.1.1
-  - xmlbf-0.3
+  - xmlbf-0.4
   - xmlbf-xeno-0.1.1


### PR DESCRIPTION
There was an issue in `xmlbf-0.3` when parsing nested elements. `xmlbf-0.4` fixes that.